### PR TITLE
Updated for 1.4.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:latest as stage1
 LABEL maintainer="John Burt"
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG VERSION=1.3.0
+ARG VERSION=1.4.0
 
 RUN \
  echo "**** install packages ****" && \
@@ -11,12 +11,14 @@ RUN \
  wget http://archive.apache.org/dist/guacamole/${VERSION}/source/guacamole-client-${VERSION}.tar.gz && \
  tar -xzf guacamole-client-${VERSION}.tar.gz && \
  cd guacamole-client-${VERSION}/ && \
+ export OPENSSL_CONF=/dev/null && \
  export JAVA_HOME=$(realpath /usr/bin/javadoc | sed 's@bin/javadoc$@@') && \
  mvn clean package -Plgpl-extensions && \
  echo $PWD
 
 
 FROM alpine:latest
+ARG VERSION
 
 COPY --from=stage1 /guacamole-client-${VERSION}/extensions/guacamole-auth-radius/target/guacamole-auth-radius-${VERSION}.jar /guacamole-auth-radius-${VERSION}.jar
 


### PR DESCRIPTION
Added line "export OPENSSL_CONF=/dev/null && \" otherwise it wouldn't compile.
Found out why here "https://github.com/bazelbuild/rules_closure/issues/351"

Also VERSION variable was not working on the copy command. Added "ARG VERSION"